### PR TITLE
Set background to cover for game and spaced winning view

### DIFF
--- a/src/containers/App/App.scss
+++ b/src/containers/App/App.scss
@@ -16,6 +16,7 @@ main {
 
 .section_game_display {
   background: url(https://cdn.suwalls.com/wallpapers/anime/studio-ghibli-characters-36913-3840x2160.jpg) no-repeat center center fixed;
+  background-size: cover;
 }
 
 h1 {

--- a/src/containers/Game/Game.scss
+++ b/src/containers/Game/Game.scss
@@ -1,9 +1,5 @@
 .game-background-img {
-  // background: url("https://cdn.suwalls.com/wallpapers/anime/studio-ghibli-characters-36913-3840x2160.jpg") no-repeat center center fixed;
-  // -webkit-background-size: cover;
-  // -moz-background-size: cover;
-  // -o-background-size: cover;
-  // background-size: cover;
+  height: 300px;
   z-index: 0;
 }
 


### PR DESCRIPTION
Could not change background opacity without altering image in editing tool outside application, but set it to cover. Learned that there is an issue winning further down the list of questions. Need to create an issue.